### PR TITLE
Fix failing tests related to childWorkflows

### DIFF
--- a/lib/LocalWorkflow/Decider/Context/actions/childWorkflow.js
+++ b/lib/LocalWorkflow/Decider/Context/actions/childWorkflow.js
@@ -1,13 +1,15 @@
-import Context from '~/lib/LocalWorkflow/Decider/Context'
-
 function childWorkflow(name, params) {
   const {
-    input,
     tasks,
     workflows,
     tasksConfig,
   } = this.data
 
+  // We can not use an import statement at the top of this file since then a
+  // circular dependency will be created. Normally this kind of problem would be
+  // resolved by injecting the Context to this module, but since this is the
+  // only action that needs it this hack is probably a lot cleaner.
+  const Context = require('~/lib/LocalWorkflow/Decider/Context').default
   const context = new Context({
     workflows,
     tasks,


### PR DESCRIPTION
The problem was a circular dependency, where Context depends on childWorkflow
which in turn, to create a new workflow needs to provide a new Context.

See http://selfcontained.us/2012/05/08/node-js-circular-dependencies/ for a good
explanation.

I chose the hacky method of requiring the Context module at runtime, since this
is probably the only action to ever need the Context module, so having Context
module injecting itself to each action seemed more complicated and pointless.