### PR TITLE
Fix deployment due to invalid CF template

### DIFF
--- a/lib/SWF/deploy/index.js
+++ b/lib/SWF/deploy/index.js
@@ -50,7 +50,12 @@ export default async function deploy(args) {
   }
 
   if (!stack) {
-    const template = generateStackTemplate({namespace})
+    const template = generateStackTemplate({
+      namespace,
+      createBucket,
+      s3Bucket,
+      s3Prefix,
+    })
     await createCFStack({region, stackName, template})
   }
 


### PR DESCRIPTION
When the ability to set a bucket prefix was introduced in acc7c4fcc, it also
included a change that the S3 bucket would not be included in the template by
default unless createBucket is true.

This broke the creation of the initial template if the stack does not exist,
since before the S3 bucket would always be included and would result in a valid
template. Once the createBucket was needed, the resulting template would not
contain the s£ bucket and would be emtpy of any resources, which is invalid.

I imagine this initial stack is used to create the S3 bucket to upload the code,
which is then used to create the full stack. Therefore providing the parameters
needed to include the S3 bucket for the initial stack creation seems like the
logical solution.