### PR TITLE
Use general tasks for decider contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ export CreateOrder from './CreateOrder'
 
 __workflows/CreateOrder.js__
 ```javascript
-export async function CreateOrder({input, actions, lambdaFunctions}) {
-  const {
-    addOrderToDatabase,
-    sendOrderConfirmation,
-  } = lambdaFunctions
-
-  const {
+export async function CreateOrder({
+  input: {
     confirmationEmailRecipient,
     products,
     customerId,
-  } = input
-
+  },
+  actions,
+  tasks: {
+    addOrderToDatabase,
+    sendOrderConfirmation,
+  }
+}) {
   const orderData = await addOrderToDatabase(customerId, products)
   await sendOrderConfirmation(orderData)
 

--- a/integration-tests/workflows/DeciderException.swf.test.js
+++ b/integration-tests/workflows/DeciderException.swf.test.js
@@ -15,6 +15,9 @@ test('SWF: DeciderException', async t => {
     id: 'DeciderException',
     type: 'DeciderException',
     version: 'integration_tests',
+    taskTypes: {
+      default: 'lambda'
+    }
   }).catch(error => {
     t.pass('rejects promise')
     t.equal(error.name, 'Error', 'forwards the error name')

--- a/integration-tests/workflows/LambdaFailure.js
+++ b/integration-tests/workflows/LambdaFailure.js
@@ -1,6 +1,8 @@
-async function LambdaFailure({lambdaFunctions}) {
-  const {failTask} = lambdaFunctions
-
+async function LambdaFailure({
+  tasks: {
+    failTask,
+  }
+}) {
   await failTask()
 }
 

--- a/integration-tests/workflows/SimpleMath.js
+++ b/integration-tests/workflows/SimpleMath.js
@@ -1,6 +1,9 @@
-async function SimpleMath({input, lambdaFunctions}) {
-  const {doubleNumber} = lambdaFunctions
-
+async function SimpleMath({
+  input,
+  tasks: {
+    doubleNumber
+  }
+}) {
   const doubledNumber = await doubleNumber(input)
   const twiceDoubledNumber = await doubleNumber(doubledNumber)
 

--- a/lib/SWF/Decider/Context/index.js
+++ b/lib/SWF/Decider/Context/index.js
@@ -1,7 +1,20 @@
 import * as actions from './actions'
 import WorkflowHistory from '~/lib/SWF/WorkflowHistory'
 
-export default function DeciderContext({workflows, tasks, events, version, namespace}) {
+export default function DeciderContext({
+  workflows,
+  tasks,
+  events,
+  version,
+  namespace,
+  config: {
+    taskTypes,
+  } = {
+    taskTypes: {
+      default: 'lambda'
+    }
+  },
+}) {
   const context = {
     workflows,
     tasks,
@@ -19,26 +32,23 @@ export default function DeciderContext({workflows, tasks, events, version, names
     {}
   )
 
-  context.lambdaFunctions = Object.keys(tasks).reduce(
+  context.tasks = Object.keys(tasks).reduce(
     (taskProxies, taskName) => ({
       ...taskProxies,
       [taskName](...args) {
-        return context.actions.lambdaFunction(taskName, args)
+        const taskType = taskTypes[taskName] || taskTypes.default || 'lambda'
+        if (taskType === 'lambda') {
+          return context.actions.lambdaFunction(taskName, args)
+        }
+        else if (taskType === 'activityTask') {
+          return context.actions.activityTask(taskName, args)
+        }
+
+        throw new Error(`Unknown task type: '${taskType}'`)
       }
     }),
     {}
   )
-
-  context.activityTasks = Object.keys(tasks).reduce(
-    (taskProxies, taskName) => ({
-      ...taskProxies,
-      [taskName](...args) {
-        return context.actions.activityTask(taskName, args)
-      }
-    }),
-    {}
-  )
-
 
   context.state = WorkflowHistory(events)
   context.input = context.state.workflowExecution.input

--- a/lib/SWF/Decider/index.js
+++ b/lib/SWF/Decider/index.js
@@ -82,6 +82,7 @@ async function Decider(options, context, callback) {
         workflows,
         events,
         tasks,
+        config: workflow.config,
       })
       const workflowDecisionPromise = workflow(deciderContext)
 


### PR DESCRIPTION
To simplify and make the workflow functions themselves be backend agnostic.
