### PR TITLE
Lower the timeout for workflow executions for integration tests

### DIFF
--- a/integration-tests/workflows/DeciderException.swf.test.js
+++ b/integration-tests/workflows/DeciderException.swf.test.js
@@ -15,6 +15,7 @@ test('SWF: DeciderException', async t => {
     id: 'DeciderException',
     type: 'DeciderException',
     version: 'integration_tests',
+    executionStartToCloseTimeout: 5,
   }).catch(error => {
     t.pass('rejects promise')
     t.equal(error.name, 'Error', 'forwards the error name')

--- a/integration-tests/workflows/LambdaFailure.swf.test.js
+++ b/integration-tests/workflows/LambdaFailure.swf.test.js
@@ -15,6 +15,7 @@ test('SWF: LambdaFailure', async t => {
     id: 'LambdaFailure',
     type: 'LambdaFailure',
     version: 'integration_tests',
+    executionStartToCloseTimeout: 5,
   }).catch(error => {
     t.pass('rejects promise')
     t.equal(error.name, 'Error', 'uses the correct error name')

--- a/integration-tests/workflows/ReceiveSignal.swf.test.js
+++ b/integration-tests/workflows/ReceiveSignal.swf.test.js
@@ -40,7 +40,7 @@ test('SWF: ReceiveSignal', async t => {
     id: workflowId,
     type: 'ReceiveSignal',
     version: 'integration_tests',
-    executionStartToCloseTimeout: 300,
+    executionStartToCloseTimeout: 5,
     input: null,
   })
   .then(result => {
@@ -70,7 +70,7 @@ test('SWF: ReceiveSignal multiple times with the same signal name', async t => {
     id: workflowId,
     type: 'ReceiveSignalMultipleTimes',
     version: 'integration_tests',
-    executionStartToCloseTimeout: 300,
+    executionStartToCloseTimeout: 5,
     input: null,
   })
   .then(result => {

--- a/integration-tests/workflows/SimpleMath.swf.test.js
+++ b/integration-tests/workflows/SimpleMath.swf.test.js
@@ -13,6 +13,7 @@ test('SWF: SimpleMath', async t => {
     id: 'SimpleMath',
     type: 'SimpleMath',
     version: 'integration_tests',
+    executionStartToCloseTimeout: 5,
     input: 2.5,
   })
 

--- a/integration-tests/workflows/WithoutReturn.test.js
+++ b/integration-tests/workflows/WithoutReturn.test.js
@@ -13,6 +13,7 @@ test('SWF: WithoutReturn', {timeout: 2000}, async t => {
     id: 'SimpleMath',
     type: 'SimpleMath',
     version: 'integration_tests',
+    executionStartToCloseTimeout: 5,
     input: 2.5,
   })
 


### PR DESCRIPTION
Especially for the ReceiveSignal tests where I had set the timout to 5 minutes,
we started to notice that when tests fail for whatever reason, the workflows
still running would cause problems for subsequent running of the tests.

I explicelty set the time to 5 seconds for all tests, rather than just  change
the two tests set to 5 minutes, since although the default is still fairly low
at 20 seconds, it might be raised in the future unwittingy causing this problem
again, and with a faster setup and teardown being worked on in PR#13 even 20
seconds might prove a little too high.