### PR TITLE
Add support for the waitForCompletion flag in local workflows

### DIFF
--- a/lib/LocalWorkflow/executeWorkflow.js
+++ b/lib/LocalWorkflow/executeWorkflow.js
@@ -1,3 +1,4 @@
+import uuid from 'uuid'
 import Context from './Context'
 import {register, markAsFailed, markAsComplete} from './StoreContext'
 import {get} from 'lodash'
@@ -9,6 +10,7 @@ async function executeWorkflow({
   input,
   tasks,
   type,
+  waitForCompletion = true,
 }) {
   const workflow = workflows[type]
 
@@ -21,16 +23,21 @@ async function executeWorkflow({
   })
 
   register(workflowId, context)
-  let result
-  try {
-    result = await workflow(context)
-  } catch (e) {
-    markAsFailed(workflowId)
-    throw e
-  }
-  markAsComplete(workflowId)
-  return result
-}
 
+  const execution = workflow(context)
+
+  execution.then(() => {
+    markAsComplete(workflowId)
+  }).catch(() => {
+    markAsFailed(workflowId)
+  })
+
+  if (waitForCompletion) {
+    return await execution
+  }
+  return {
+    runId: uuid()
+  }
+}
 
 export default executeWorkflow

--- a/lib/LocalWorkflow/executeWorkflow.test.js
+++ b/lib/LocalWorkflow/executeWorkflow.test.js
@@ -19,3 +19,24 @@ test('LocalWorkflow.executeWorkflow()', {timeout: 1000}, async t => {
 
   t.isEqual(result, 4, 'Returns the result of the workflow')
 })
+
+test('LocalWorkflow.executeWorkflow() with waitForCompletion set to false', async t => {
+  const result = await executeWorkflow({
+    type: 'Test',
+    waitForCompletion: false,
+    input: 2,
+    workflows: {
+      async Test({input, tasks: {doubleNumber}}) {
+        return doubleNumber(input)
+      },
+    },
+    tasks: {
+      async doubleNumber(number) {
+        return number * 2
+      }
+    },
+  })
+
+  t.ok(result.runId, 'Returns an execution result')
+  t.isEqual('string', typeof result.runId, 'The runId is a string')
+})


### PR DESCRIPTION
It is a flag available when using the real SWF, and since in a project I want to
sometimes wait for the response and in other cases just fire off an execution it
makes things a lot simpler if the same flag can be used across both the workflow
types.