### PR TITLE
Update lambda NodeJS runtime to use version 8.10 by default

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "ignore": ["node_modules/"],
   "env": {
-    "6.13.0": {
+    "8.10.0": {
       "plugins": [
         "transform-object-rest-spread",
         "transform-async-generator-functions",
@@ -12,7 +12,7 @@
           "env",
           {
             "targets": {
-              "node": "6.13.0"
+              "node": "8.10.0"
             }
           }
         ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM trym/watchexec-alpine as watchexec
-FROM node:6.13.0-alpine
+FROM node:8.10.0-alpine
 FROM node:9.6.1-alpine as production
 
 COPY --from=watchexec /bin/watchexec /bin
-COPY --from=node:6.13.0-alpine /usr/local /usr/local-6.13.0
+COPY --from=node:8.10.0-alpine /usr/local /usr/local-8.10.0
 
 # Prepare node binary links/wrappers in /node
 RUN \
   mkdir -p /node && \
-  ln -s /usr/local-6.13.0/bin/node /node/6.13.0 && \
+  ln -s /usr/local-8.10.0/bin/node /node/8.10.0 && \
   ln -s /usr/local/bin/node /node/9.6.1-native
 
-ENV NODE_TARGETS="6.13.0 9.6.1-native"
+ENV NODE_TARGETS="8.10.0 9.6.1-native"
 
 RUN apk -U add bash git rsync
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Easily run distributed workflows with AWS [Simple Workflow Service](https://aws.
 
 ## Installation
 
-> A minimum of node 6.5.0 is required
+> A minimum of node 8.10.0 is required
 
 ```bash
 yarn add soflow
@@ -89,7 +89,7 @@ const deployPromise = SWF.Orchestration.setup({
   progressIndicator: true   // default: false
   deciderEnvironment: {
     // environment variables available in lambda decider worklow functions
-    MY_CUSTOM_ENVIRONMENT_VARIABLE: 'myvalue', 
+    MY_CUSTOM_ENVIRONMENT_VARIABLE: 'myvalue',
   }
   // File glob patterns to include in the lambda package.
   // Everything needed by your tasks must be included (including the soflow npm module).
@@ -161,12 +161,12 @@ activityWorker.start()
 
 #### Lambda decider
 
-> Soflow supports running SWF deciders as Lamda functions.  
+> Soflow supports running SWF deciders as Lamda functions.
 > Due to the nature of Lambda and SWF, the implementation has some important details.
 
 ##### Enable lambda decider
 
-> When the lambda decider is enabled, soflow enables a scheduled CloudWatch event rule that triggers the decider lambda function every minute.  
+> When the lambda decider is enabled, soflow enables a scheduled CloudWatch event rule that triggers the decider lambda function every minute.
 > The lambda function will run for 65-130 seconds, exiting when there no longer time (60s + 5s slack) to do an empty poll. This is to prevent decision tasks being temporarily "stuck".
 > This means between 1 and 2 deciders are running at any given time, each able to handle multiple decision tasks concurrenctly.
 >
@@ -244,7 +244,7 @@ async function teardownExample() {
 
 ### Executing workflow without AWS
 
-Soflow provides a limited LocalWorkflow backend, with the same API as the SWF backend.  
+Soflow provides a limited LocalWorkflow backend, with the same API as the SWF backend.
 This can be useful during development or testing, but be aware that it:
 
 * runs all workflow (decider) functions in the current process
@@ -328,9 +328,9 @@ soflow clean   # stops/cleans docker containers, tmux session
 # Unit and integration tests for all node targets
 docker-compose exec dev scripts/test
 
-# Unit tests for node 6.13.0 with file watching and verbose output
+# Unit tests for node 8.10.0 with file watching and verbose output
 docker-compose exec dev ash -c \
-  "NODE_TARGETS=6.13.0 scripts/unit-tests --watch --verbose"
+  "NODE_TARGETS=8.10.0 scripts/unit-tests --watch --verbose"
 
 # Integration tests with 'local' profile and untranspiled code using node 9.6.1
 docker-compose exec dev ash -c \

--- a/lib/SWF/Orchestration/setup/components/decider.js
+++ b/lib/SWF/Orchestration/setup/components/decider.js
@@ -77,9 +77,9 @@ module.exports = function({
           description: 'soflow decider',
           handler: path.join(
             soflowPath,
-            'lib-6_13_0/SWF/Orchestration/Lambda/deciderHandler.handler'
+            'lib-8_10_0/SWF/Orchestration/Lambda/deciderHandler.handler'
           ),
-          runtime: 'nodejs6.10',
+          runtime: 'nodejs8.10',
           memorySize: 128,
           timeout: (60 + config.lambdaDeciderPolltimeSlackInSeconds) * 2, // 60 seconds per poll + some slack
           environment: {

--- a/lib/SWF/Orchestration/setup/components/lambdaFunctions.js
+++ b/lib/SWF/Orchestration/setup/components/lambdaFunctions.js
@@ -52,7 +52,7 @@ module.exports = function({
       environment,
       permissions,
       concurrency,
-      runtime = 'nodejs6.10',
+      runtime = 'nodejs8.10',
     } = get(task, 'config', {})
 
     const functionName = awsName.lambda(`${namespace}_${taskName}`)
@@ -150,7 +150,7 @@ module.exports = function({
           description,
           handler: path.join(
             soflowPath,
-            `lib-6_13_0/SWF/Orchestration/Lambda/wrappedTasks.${taskName}`
+            `lib-8_10_0/SWF/Orchestration/Lambda/wrappedTasks.${taskName}`
           ),
           runtime,
           memorySize,

--- a/lib/SWF/Orchestration/setup/components/uploadCode.js
+++ b/lib/SWF/Orchestration/setup/components/uploadCode.js
@@ -27,7 +27,7 @@ module.exports = function({
   const s3 = new config.AWS.S3()
 
   const baseFilesGlobs = [
-    `${soflowPath}/lib-6_13_0/**`,
+    `${soflowPath}/lib-8_10_0/**`,
     `${soflowPath}/+(package.json|main.js)`,
     `${modulesPath}/serialize-error/**`,
     `${modulesPath}/lodash.get/**`,

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const version = process.versions.node
 if (semver.satisfies(version, '>= 9.0.0')) {
   module.exports = require('./lib')
 } else if (semver.satisfies(version, '>= 6.5.0')) {
-  module.exports = require('./lib-6_13_0')
+  module.exports = require('./lib-8_10_0')
 } else {
-  throw new Error('NodeJS 6.5.0 or newer is required')
+  throw new Error('NodeJS 8.10.0 or newer is required')
 }

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -23,10 +23,10 @@ if [[ $watchRequested ]]; then
   exit 0
 fi
 
-if [[ $NODE_TARGETS = *"6.13.0"* ]]; then
+if [[ $NODE_TARGETS = *"8.10.0"* ]]; then
   scripts/build
 else
-  NODE_TARGETS="$NODE_TARGETS 6.13.0" scripts/build
+  NODE_TARGETS="$NODE_TARGETS 8.10.0" scripts/build
 fi
 
 
@@ -40,7 +40,7 @@ do
   sanitizedNodeVersion=$(echo $nodeVersion | tr . _)
   export NODE_TARGET=$sanitizedNodeVersion
   export SOFLOW_NAMESPACE=${SOFLOW_NAMESPACE}-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 9 | head -n 1)
-  
+
   echo -e "\n# Integration tests (node $nodeVersion)"
   echo -e "# namespace: $SOFLOW_NAMESPACE"
 
@@ -49,11 +49,11 @@ do
   $node $ava "**/*.test.js" -c 8 -T 10s $passThroughArgs
   failed=$?
   cd ..
-  
+
   # Cleanup
   export SOFLOW_NAMESPACE=$SOFLOW_ROOT_NAMESPACE
   $node test-$sanitizedNodeVersion/scripts/teardown.js
-  $node test-$sanitizedNodeVersion/scripts/clean-up-s3-buckets.js $SOFLOW_ROOT_NAMESPACE 
+  $node test-$sanitizedNodeVersion/scripts/clean-up-s3-buckets.js $SOFLOW_ROOT_NAMESPACE
 
   [[ $failed -eq 1 ]] && exit 1
 done

--- a/test.js
+++ b/test.js
@@ -3,8 +3,8 @@ const version = process.versions.node
 
 if (semver.satisfies(version, '>= 9.0.0')) {
   module.exports = require('./test/helpers')
-} else if (semver.satisfies(version, '>= 6.5.0')) {
-  module.exports = require('./test-6_13_0/helpers')
+} else if (semver.satisfies(version, '>= 8.10.0')) {
+  module.exports = require('./test-8_10_0/helpers')
 } else {
-  throw new Error('NodeJS 6.5.0 or newer is required')
+  throw new Error('NodeJS 8.10.0 or newer is required')
 }

--- a/test/scripts/setup.js
+++ b/test/scripts/setup.js
@@ -4,17 +4,17 @@ async function setup() {
   if (!process.env.PROFILES || process.env.PROFILES.includes('swf')) {
     return SWF.Orchestration.setup({
       codeRoot: '/soflow',
-      workflowsPath: 'test-6_13_0/workflows',
-      tasksPath: 'test-6_13_0/tasks',
+      workflowsPath: 'test-8_10_0/workflows',
+      tasksPath: 'test-8_10_0/tasks',
       includeBaseFiles: false,
       files: [
         [
           'lambda-modules/**',
           path => path.replace('lambda-modules', 'node_modules'),
         ],
-        ['lib-6_13_0/**', path => !path.endsWith('.test.js')],
-        'test-6_13_0/workflows/**',
-        'test-6_13_0/tasks/**',
+        ['lib-8_10_0/**', path => !path.endsWith('.test.js')],
+        'test-8_10_0/workflows/**',
+        'test-8_10_0/tasks/**',
         '+(package.json|main.js)',
       ],
       ignore: [


### PR DESCRIPTION
AWS no longer supports 6, so it does not make sense to have that as the default.