### PR TITLE
Support configuring the node runtime used for tasks in local workflows

### DIFF
--- a/lib/LocalWorkflow/DecisionContext/index.js
+++ b/lib/LocalWorkflow/DecisionContext/index.js
@@ -16,6 +16,7 @@ class DecisionContext {
     state = {timers: {}, incomingSignals: {}, incomingSignalListeners: {}},
     workflowId,
     input,
+    nodeCommand = defaultConfig.nodeCommand,
     codeRoot = defaultConfig.codeRoot,
     tasksPath = defaultConfig.tasksPath,
     workflowsPath = defaultConfig.workflowsPath,
@@ -30,6 +31,7 @@ class DecisionContext {
       workflowId,
       state,
       config: {
+        nodeCommand,
         codeRoot,
         tasksPath,
         workflowsPath,

--- a/lib/LocalWorkflow/DecisionContext/runTaskInChildProcess.js
+++ b/lib/LocalWorkflow/DecisionContext/runTaskInChildProcess.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const config = require('../../config')
 const {serializeError} = require('serialize-error')
 const {spawn} = require('child_process')
 const os = require('os')
@@ -15,7 +14,7 @@ async function runTaskInChildProcess(context, {name, args, timeout}) {
 
   await new Promise((resolve, reject) => {
     const taskProcess = spawn(
-      config.nodeCommand,
+      context.config.nodeCommand,
       [
         __filename,
         `${context.config.codeRoot}/${context.config.tasksPath}`,

--- a/lib/LocalWorkflow/executeWorkflow.js
+++ b/lib/LocalWorkflow/executeWorkflow.js
@@ -6,6 +6,7 @@ function executeWorkflow({
   type,
   input,
   workflowId,
+  nodeCommand = config.nodeCommand,
   codeRoot = config.codeRoot,
   workflowsPath = config.workflowsPath,
   tasksPath = config.tasksPath,
@@ -14,6 +15,7 @@ function executeWorkflow({
   const workflowFunction = workflows[type]
   const decisionContext = new DecisionContext({
     input,
+    nodeCommand,
     codeRoot,
     workflowsPath,
     tasksPath,


### PR DESCRIPTION
The primary purpose of using the local workflow is to make development easier by
not needing to deploy changes to SWF all the time. Currently this is a bit of a
pain to setup if your project is compiled (eg. typescript), since the tasks need
to first be compiled and executing the workflow locally requires pointing it to
those compiled files. Instead, I think it would be easier to just configure a
different node runtime, so that `ts-node` could be used instead, which avoids
having to compile first.

It could be argued that doing this further increases the chance of differences
between your tasks running locally and when running in production using the real
AWS SWF framework. However:
- There is already no guarantee that the node binary running locally will the
  same as when your activity task is running in production. Especially true if
  you run your tasks as AWS lambda functions.
- The workflows are still running in whatever process they are triggered, so if
  you are using typescript chances are you workflow logic is already running via
  `ts-node`.
- The main reason for running tasks as separate processes was to ensure that the
  behaviour of passing data back to the workflow reflected the same limitations
  when using the real SWF, which means the data must be serialised and not just
  passed as a reference. This will still hold true regardless of the runtime
  used.