### PR TITLE
Bump lambda runtime from nodejs10.x to nodejs14.x

### DIFF
--- a/lib/SWF/Orchestration/setup/components/decider.js
+++ b/lib/SWF/Orchestration/setup/components/decider.js
@@ -79,7 +79,7 @@ module.exports = function({
             soflowPath,
             'lib/SWF/Orchestration/Lambda/deciderHandler.handler'
           ),
-          runtime: 'nodejs10.x',
+          runtime: 'nodejs14.x',
           memorySize: 128,
           timeout: (60 + config.lambdaDeciderPolltimeSlackInSeconds) * 2, // 60 seconds per poll + some slack
           environment: {

--- a/lib/SWF/Orchestration/setup/components/lambdaFunctions.js
+++ b/lib/SWF/Orchestration/setup/components/lambdaFunctions.js
@@ -52,7 +52,7 @@ module.exports = function({
       environment,
       permissions,
       concurrency,
-      runtime = 'nodejs10.x',
+      runtime = 'nodejs14.x',
     } = get(task, 'config', {})
 
     const functionName = awsName.lambda(`${namespace}_${taskName}`)


### PR DESCRIPTION
`nodejs10.x` is [no longer supported](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) as a lambda runtime. Bumping relevant configuration to `nodejs14.x`
